### PR TITLE
fix: update generator script to handle absolute URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vega-docs/
 vega.docset/
 vega.tgz
 .DS_Store
+.ipynb_checkpoints/

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ A Python script to generate offline documentation for [vega](https://github.com/
 This step is only necessary if you intend to hack on the published docset locally. Otherwise, it can be installed from the Dash app or the [Dash contributions repository](https://github.com/Kapeli/Dash-User-Contributions).
 
 1. Clone `vega` as a sibling folder of this repository using the changes from [this PR](https://github.com/vega/vega/pull/3280).
-2. In that directory, run `yarn install && yarn build && yarn build:static` to generate the site
-  a. You may need to install `rbenv` and `Jekyll` to build the documentation site.
+2. In that directory, run `yarn install && yarn build && yarn docs:static` to generate the site
+  a. You may need to install `rbenv`, a current version of Ruby, and `Jekyll` to build the documentation site.
 3. In your python virtual environment, add python dependencies: `pip install -r requirements.txt`
   a. Using Jupyter is optional, but recommended for ease of debugging the notebook output.
 4. Run `jupyter notebook`, and select `generate-vega-docset.ipynb`. Run all cells.

--- a/generate-vega-docset.ipynb
+++ b/generate-vega-docset.ipynb
@@ -2,55 +2,59 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
-    "# build-vega-lite-docset\n",
+    "# build-vega-docset\n",
     "\n",
-    "> Converts a built copy of the vega-lite static Jekyll site to a docset directory"
-   ],
-   "metadata": {}
+    "> Converts a built copy of the vega static Jekyll site to a docset directory"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "\n",
-    "1. Clone `vega-lite` as a sibling folder of this repository using the changes from [this PR](https://github.com/vega/vega-lite/pull/7642)\n",
-    "2. In that directory, run `yarn install && yarn docset`\n",
-    "3. In your python virtual environment, add these dependencies: `pip install bs4 lxml`\n",
-    "4. Using Jupyter is optional, but recommended for ease of debugging"
-   ],
-   "metadata": {}
+    "1. Clone `vega` as a sibling folder of this repository using the changes from [this PR](https://github.com/vega/vega/pull/3280)\n",
+    "2. In that directory, run `yarn install && yarn build && yarn docs:static`\n",
+    "3. In your python virtual environment, add these dependencies: `pip install -r requirements.txt`\n",
+    "4. Using Jupyter is optional, but recommended for ease of debugging\n",
+    "\n",
+    "Note: To debug the docset, rename it to a plain directory, then use SQLite browser to inspect the contents [link](https://sqlitebrowser.org/dl/)"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
-   "source": [
-    "# Make a folder to hold a copy of the built site\n",
-    "!mkdir vega-docs"
-   ],
+   "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "mkdir: vega-docs: File exists\n"
+      "mkdir: cannot create directory ‘vega-docs’: File exists\n"
      ]
     }
    ],
-   "metadata": {}
+   "source": [
+    "# Make a folder to hold a copy of the built site\n",
+    "!mkdir vega-docs"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# initial import of built site assets\n",
     "!rsync -r ../vega/docs/_site/* ./vega-docs"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "import glob\n",
     "import os\n",
@@ -61,61 +65,61 @@
     "\n",
     "from bs4 import BeautifulSoup\n",
     "# from bs4.element import NavigableString"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "DEBUG = True"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "DOCSET_NAME = 'vega'"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "DOCSET_PATH = f\"{DOCSET_NAME}.docset/Contents/Resources/Documents/\""
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# Create a folder to hold your docset info\n",
     "!mkdir -p $DOCSET_PATH"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "VEGA_DOCSET = f\"{DOCSET_NAME}.docset\"\n",
     "PLIST_PATH = f\"{DOCSET_NAME}.docset/Contents/Info.plist\"\n",
     "SQLITE_PATH = f\"{DOCSET_NAME}.docset/Contents/Resources/docSet.dsidx\""
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# Create Info.plist\n",
     "docsetIndex = '''<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n",
@@ -145,13 +149,13 @@
     "\n",
     "with open('vega.docset/Contents/Info.plist', 'w') as fp:\n",
     "    fp.write(docsetIndex)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "\n",
     "# string to handle with replacement\n",
@@ -169,31 +173,18 @@
     "    depthString = getDepthString(depth)\n",
     "\n",
     "    return text.replace(DOCSET_BASE, depthString)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 11,
-   "source": [
-    "# Convert absolute to relative URLs\n",
-    "matches = glob.glob(f\"vega-docs/**/*.html\", recursive=True)\n",
-    "print(len(matches))\n",
-    "# now let's clean up the source files\n",
-    "for name in matches:\n",
-    "    if DEBUG:\n",
-    "        print('Moving relative urls', name)\n",
-    "    processed = update_relative_paths(name)\n",
-    "    with open(name, 'w') as fp:\n",
-    "        fp.write(processed)"
-   ],
+   "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "188\n",
+      "192\n",
       "Moving relative urls vega-docs/index.html\n",
       "Moving relative urls vega-docs/usage/index.html\n",
       "Moving relative urls vega-docs/usage/interpreter/index.html\n",
@@ -306,6 +297,7 @@
       "Moving relative urls vega-docs/examples/edge-bundling/index.html\n",
       "Moving relative urls vega-docs/examples/connected-scatter-plot/index.html\n",
       "Moving relative urls vega-docs/examples/wheat-and-wages/index.html\n",
+      "Moving relative urls vega-docs/examples/zoomable-circle-packing/index.html\n",
       "Moving relative urls vega-docs/examples/word-cloud/index.html\n",
       "Moving relative urls vega-docs/examples/u-district-cuisine/index.html\n",
       "Moving relative urls vega-docs/examples/scatter-plot-null-values/index.html\n",
@@ -325,6 +317,7 @@
       "Moving relative urls vega-docs/examples/bar-chart/index.html\n",
       "Moving relative urls vega-docs/examples/population-pyramid/index.html\n",
       "Moving relative urls vega-docs/examples/global-development/index.html\n",
+      "Moving relative urls vega-docs/examples/serpentine-timeline/index.html\n",
       "Moving relative urls vega-docs/examples/annual-temperature/index.html\n",
       "Moving relative urls vega-docs/examples/projections/index.html\n",
       "Moving relative urls vega-docs/examples/top-k-plot-with-others/index.html\n",
@@ -358,6 +351,7 @@
       "Moving relative urls vega-docs/examples/heatmap/index.html\n",
       "Moving relative urls vega-docs/examples/dot-plot/index.html\n",
       "Moving relative urls vega-docs/examples/probability-density/index.html\n",
+      "Moving relative urls vega-docs/examples/warming-stripes/index.html\n",
       "Moving relative urls vega-docs/examples/horizon-graph/index.html\n",
       "Moving relative urls vega-docs/examples/regression/index.html\n",
       "Moving relative urls vega-docs/examples/volcano-contours/index.html\n",
@@ -374,6 +368,7 @@
       "Moving relative urls vega-docs/examples/nested-bar-chart/index.html\n",
       "Moving relative urls vega-docs/examples/radial-tree-layout/index.html\n",
       "Moving relative urls vega-docs/examples/clock/index.html\n",
+      "Moving relative urls vega-docs/examples/packed-bubble-chart/index.html\n",
       "Moving relative urls vega-docs/examples/earthquakes/index.html\n",
       "Moving relative urls vega-docs/examples/histogram/index.html\n",
       "Moving relative urls vega-docs/examples/dorling-cartogram/index.html\n",
@@ -385,24 +380,37 @@
      ]
     }
    ],
-   "metadata": {}
+   "source": [
+    "# Convert absolute to relative URLs\n",
+    "matches = glob.glob(f\"vega-docs/**/*.html\", recursive=True)\n",
+    "print(len(matches))\n",
+    "# now let's clean up the source files\n",
+    "for name in matches:\n",
+    "    if DEBUG:\n",
+    "        print('Moving relative urls', name)\n",
+    "    processed = update_relative_paths(name)\n",
+    "    with open(name, 'w') as fp:\n",
+    "        fp.write(processed)"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# Then get entries to add to the database\n",
     "def get_soup(filename):\n",
     "    with open(filename) as fp:\n",
     "        text = fp.read()\n",
     "    return BeautifulSoup(text, 'lxml')"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "def get_guide_entries():\n",
     "    tutorial_soup = get_soup(\"vega-docs/tutorials/index.html\")\n",
@@ -444,7 +452,8 @@
     "        [\n",
     "            l.getText().strip(),\n",
     "            \"Guide\",\n",
-    "            path.join('/', path.relpath(l[\"href\"], \"../\"), 'index.html')\n",
+    "            # Need to avoid making relative paths if it's to a direct link\n",
+    "            path.join('/', path.relpath(l[\"href\"], \"../\"), 'index.html') if not 'https:' in l[\"href\"] else l[\"href\"]\n",
     "        ]\n",
     "        for l in about_links\n",
     "    ]\n",
@@ -457,19 +466,14 @@
     "        # ['Comparison', 'Guide', '/comparison.html'],\n",
     "        #  ['Overview', 'Guide', '/index.html'],   # not needed, is main page\n",
     "    ]"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 14,
-   "source": [
-    "get_guide_entries()"
-   ],
+   "metadata": {},
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "[['Let’s Make a Bar Chart', 'Guide', '/tutorials/bar-chart/index.html'],\n",
@@ -489,27 +493,34 @@
        " ['Projects', 'Guide', '/about/projects/index.html'],\n",
        " ['Research', 'Guide', '/about/research/index.html'],\n",
        " ['Vega and D3', 'Guide', '/about/vega-and-d3/index.html'],\n",
-       " ['Code of Conduct', 'Guide', '/about/code-of-conduct/index.html']]"
+       " ['Code of Conduct',\n",
+       "  'Guide',\n",
+       "  'https://github.com/vega/.github/blob/master/CODE_OF_CONDUCT.md']]"
       ]
      },
+     "execution_count": 14,
      "metadata": {},
-     "execution_count": 14
+     "output_type": "execute_result"
     }
    ],
-   "metadata": {}
+   "source": [
+    "get_guide_entries()"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "#get_sample_entries()"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "def get_sample_entries():\n",
     "    examples_soup = get_soup('vega-docs/examples/index.html')\n",
@@ -523,32 +534,32 @@
     "    ]\n",
     "    \n",
     "    return entries"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Notes on docs\n",
     "\n",
     "- API has 1 level of nesting per page\n",
     "- Spec has 1 level of nesting for most, except for Mark and Transforms"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "#get_structures_entries()"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# Process the \"docs\" part of the site directory\n",
     "def get_structures_entries():\n",
@@ -612,22 +623,22 @@
     "        *transforms_entries,\n",
     "    ]\n",
     "    "
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "all_entries = [*get_guide_entries(), *get_sample_entries(), *get_structures_entries()]"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 20,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# Add 1 row\n",
     "def addRow(cursor, name, rowType, path):\n",
@@ -635,16 +646,214 @@
     "    if DEBUG:\n",
     "        print(statement)\n",
     "    cursor.execute(statement)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Let’s Make a Bar Chart', 'Guide', '/tutorials/bar-chart/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('A Guide to Guides: Axes & Legends', 'Guide', 'https://observablehq.com/@vega/a-guide-to-guides-axes-legends-in-vega');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Mapping Airport Connections', 'Guide', '/tutorials/airports/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('How Vega Works', 'Guide', 'https://observablehq.com/@vega/how-vega-works');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Usage: Main', 'Guide', '/usage/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Usage: Internet Explorer', 'Guide', '/usage/internet-explorer/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Usage: Interpreter', 'Guide', '/usage/interpreter/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Documentation: Main', 'Guide', '/docs/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Debugging', 'Guide', '/docs/api/debugging/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Extensibility', 'Guide', '/docs/api/extensibility/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('About', 'Guide', '/about/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Video', 'Guide', '/about/video/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Projects', 'Guide', '/about/projects/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Research', 'Guide', '/about/research/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Vega and D3', 'Guide', '/about/vega-and-d3/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Code of Conduct', 'Guide', 'https://github.com/vega/.github/blob/master/CODE_OF_CONDUCT.md');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Bar Chart', 'Sample', '/examples/bar-chart/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Stacked Bar Chart', 'Sample', '/examples/stacked-bar-chart/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Grouped Bar Chart', 'Sample', '/examples/grouped-bar-chart/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Nested Bar Chart', 'Sample', '/examples/nested-bar-chart/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Population Pyramid', 'Sample', '/examples/population-pyramid/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Line Chart', 'Sample', '/examples/line-chart/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Area Chart', 'Sample', '/examples/area-chart/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Stacked Area Chart', 'Sample', '/examples/stacked-area-chart/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Horizon Graph', 'Sample', '/examples/horizon-graph/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Job Voyager', 'Sample', '/examples/job-voyager/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Pie Chart', 'Sample', '/examples/pie-chart/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Donut Chart', 'Sample', '/examples/donut-chart/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Radial Plot', 'Sample', '/examples/radial-plot/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Radar Chart', 'Sample', '/examples/radar-chart/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Scatter Plot', 'Sample', '/examples/scatter-plot/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Scatter Plot Null Values', 'Sample', '/examples/scatter-plot-null-values/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Connected Scatter Plot', 'Sample', '/examples/connected-scatter-plot/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Error Bars', 'Sample', '/examples/error-bars/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Barley Trellis Plot', 'Sample', '/examples/barley-trellis-plot/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Regression', 'Sample', '/examples/regression/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Loess Regression', 'Sample', '/examples/loess-regression/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Labeled Scatter Plot', 'Sample', '/examples/labeled-scatter-plot/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Top K Plot', 'Sample', '/examples/top-k-plot/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Top K Plot With Others', 'Sample', '/examples/top-k-plot-with-others/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Histogram', 'Sample', '/examples/histogram/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Histogram Null Values', 'Sample', '/examples/histogram-null-values/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Dot Plot', 'Sample', '/examples/dot-plot/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Probability Density', 'Sample', '/examples/probability-density/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Box Plot', 'Sample', '/examples/box-plot/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Violin Plot', 'Sample', '/examples/violin-plot/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Binned Scatter Plot', 'Sample', '/examples/binned-scatter-plot/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Contour Plot', 'Sample', '/examples/contour-plot/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Wheat Plot', 'Sample', '/examples/wheat-plot/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Quantile Quantile Plot', 'Sample', '/examples/quantile-quantile-plot/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Quantile Dot Plot', 'Sample', '/examples/quantile-dot-plot/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Hypothetical Outcome Plots', 'Sample', '/examples/hypothetical-outcome-plots/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Time Units', 'Sample', '/examples/time-units/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('County Unemployment', 'Sample', '/examples/county-unemployment/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Dorling Cartogram', 'Sample', '/examples/dorling-cartogram/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('World Map', 'Sample', '/examples/world-map/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Earthquakes', 'Sample', '/examples/earthquakes/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Projections', 'Sample', '/examples/projections/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Zoomable World Map', 'Sample', '/examples/zoomable-world-map/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Distortion Comparison', 'Sample', '/examples/distortion-comparison/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Volcano Contours', 'Sample', '/examples/volcano-contours/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Wind Vectors', 'Sample', '/examples/wind-vectors/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Annual Precipitation', 'Sample', '/examples/annual-precipitation/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Tree Layout', 'Sample', '/examples/tree-layout/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Radial Tree Layout', 'Sample', '/examples/radial-tree-layout/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Treemap', 'Sample', '/examples/treemap/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Circle Packing', 'Sample', '/examples/circle-packing/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Sunburst', 'Sample', '/examples/sunburst/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Edge Bundling', 'Sample', '/examples/edge-bundling/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Force Directed Layout', 'Sample', '/examples/force-directed-layout/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Reorderable Matrix', 'Sample', '/examples/reorderable-matrix/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Arc Diagram', 'Sample', '/examples/arc-diagram/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Airport Connections', 'Sample', '/examples/airport-connections/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Heatmap', 'Sample', '/examples/heatmap/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Density Heatmaps', 'Sample', '/examples/density-heatmaps/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Parallel Coordinates', 'Sample', '/examples/parallel-coordinates/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Word Cloud', 'Sample', '/examples/word-cloud/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Beeswarm Plot', 'Sample', '/examples/beeswarm-plot/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Calendar View', 'Sample', '/examples/calendar-view/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Packed Bubble Chart', 'Sample', '/examples/packed-bubble-chart/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Budget Forecasts', 'Sample', '/examples/budget-forecasts/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Wheat And Wages', 'Sample', '/examples/wheat-and-wages/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Falkensee Population', 'Sample', '/examples/falkensee-population/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Annual Temperature', 'Sample', '/examples/annual-temperature/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Weekly Temperature', 'Sample', '/examples/weekly-temperature/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Flight Passengers', 'Sample', '/examples/flight-passengers/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Timelines', 'Sample', '/examples/timelines/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('U District Cuisine', 'Sample', '/examples/u-district-cuisine/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Clock', 'Sample', '/examples/clock/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Watch', 'Sample', '/examples/watch/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Warming Stripes', 'Sample', '/examples/warming-stripes/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Serpentine Timeline', 'Sample', '/examples/serpentine-timeline/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Crossfilter Flights', 'Sample', '/examples/crossfilter-flights/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Overview Plus Detail', 'Sample', '/examples/overview-plus-detail/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Brushing Scatter Plots', 'Sample', '/examples/brushing-scatter-plots/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Zoomable Scatter Plot', 'Sample', '/examples/zoomable-scatter-plot/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Zoomable Binned Plot', 'Sample', '/examples/zoomable-binned-plot/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Global Development', 'Sample', '/examples/global-development/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Interactive Legend', 'Sample', '/examples/interactive-legend/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Stock Index Chart', 'Sample', '/examples/stock-index-chart/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Pi Monte Carlo', 'Sample', '/examples/pi-monte-carlo/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Zoomable Circle Packing', 'Sample', '/examples/zoomable-circle-packing/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Pacman', 'Sample', '/examples/pacman/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Platformer', 'Sample', '/examples/platformer/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Specification', 'Category', '/docs/specification/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Config', 'Category', '/docs/config/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Data', 'Category', '/docs/data/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Transforms', 'Category', '/docs/transforms/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Triggers', 'Category', '/docs/triggers/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Projections', 'Category', '/docs/projections/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Scales', 'Category', '/docs/scales/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Schemes', 'Category', '/docs/schemes/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Axes', 'Category', '/docs/axes/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Legends', 'Category', '/docs/legends/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Title', 'Category', '/docs/title/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Marks', 'Category', '/docs/marks/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Signals', 'Category', '/docs/signals/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Event Streams', 'Category', '/docs/event-streams/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Expressions', 'Category', '/docs/expressions/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Layout', 'Category', '/docs/layout/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Types', 'Category', '/docs/types/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Parser', 'Module', '/docs/api/parser/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('View', 'Module', '/docs/api/view/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Locale', 'Module', '/docs/api/locale/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Statistics', 'Module', '/docs/api/statistics/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Time', 'Module', '/docs/api/time/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('Util', 'Module', '/docs/api/util/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('mark.arc', 'Interface', '/docs/marks/arc/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('mark.area', 'Interface', '/docs/marks/area/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('mark.group', 'Interface', '/docs/marks/group/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('mark.image', 'Interface', '/docs/marks/image/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('mark.line', 'Interface', '/docs/marks/line/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('mark.path', 'Interface', '/docs/marks/path/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('mark.rect', 'Interface', '/docs/marks/rect/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('mark.rule', 'Interface', '/docs/marks/rule/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('mark.shape', 'Interface', '/docs/marks/shape/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('mark.symbol', 'Interface', '/docs/marks/symbol/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('mark.text', 'Interface', '/docs/marks/text/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('mark.trail', 'Interface', '/docs/marks/trail/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('transform.aggregate', 'Interface', '/docs/transforms/aggregate/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('transform.bin', 'Interface', '/docs/transforms/bin/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('transform.collect', 'Interface', '/docs/transforms/collect/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('transform.countpattern', 'Interface', '/docs/transforms/countpattern/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('transform.contour', 'Interface', '/docs/transforms/contour/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('transform.cross', 'Interface', '/docs/transforms/cross/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('transform.crossfilter', 'Interface', '/docs/transforms/crossfilter/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('transform.density', 'Interface', '/docs/transforms/density/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('transform.dotbin', 'Interface', '/docs/transforms/dotbin/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('transform.extent', 'Interface', '/docs/transforms/extent/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('transform.filter', 'Interface', '/docs/transforms/filter/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('transform.flatten', 'Interface', '/docs/transforms/flatten/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('transform.fold', 'Interface', '/docs/transforms/fold/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('transform.force', 'Interface', '/docs/transforms/force/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('transform.formula', 'Interface', '/docs/transforms/formula/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('transform.geojson', 'Interface', '/docs/transforms/geojson/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('transform.geopath', 'Interface', '/docs/transforms/geopath/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('transform.geopoint', 'Interface', '/docs/transforms/geopoint/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('transform.geoshape', 'Interface', '/docs/transforms/geoshape/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('transform.graticule', 'Interface', '/docs/transforms/graticule/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('transform.heatmap', 'Interface', '/docs/transforms/heatmap/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('transform.identifier', 'Interface', '/docs/transforms/identifier/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('transform.impute', 'Interface', '/docs/transforms/impute/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('transform.isocontour', 'Interface', '/docs/transforms/isocontour/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('transform.joinaggregate', 'Interface', '/docs/transforms/joinaggregate/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('transform.kde', 'Interface', '/docs/transforms/kde/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('transform.kde2d', 'Interface', '/docs/transforms/kde2d/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('transform.label', 'Interface', '/docs/transforms/label/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('transform.linkpath', 'Interface', '/docs/transforms/linkpath/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('transform.loess', 'Interface', '/docs/transforms/loess/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('transform.lookup', 'Interface', '/docs/transforms/lookup/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('transform.nest', 'Interface', '/docs/transforms/nest/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('transform.pack', 'Interface', '/docs/transforms/pack/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('transform.partition', 'Interface', '/docs/transforms/partition/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('transform.pie', 'Interface', '/docs/transforms/pie/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('transform.pivot', 'Interface', '/docs/transforms/pivot/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('transform.project', 'Interface', '/docs/transforms/project/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('transform.quantile', 'Interface', '/docs/transforms/quantile/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('transform.regression', 'Interface', '/docs/transforms/regression/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('transform.resolvefilter', 'Interface', '/docs/transforms/resolvefilter/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('transform.sample', 'Interface', '/docs/transforms/sample/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('transform.sequence', 'Interface', '/docs/transforms/sequence/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('transform.stack', 'Interface', '/docs/transforms/stack/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('transform.stratify', 'Interface', '/docs/transforms/stratify/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('transform.timeunit', 'Interface', '/docs/transforms/timeunit/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('transform.tree', 'Interface', '/docs/transforms/tree/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('transform.treelinks', 'Interface', '/docs/transforms/treelinks/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('transform.treemap', 'Interface', '/docs/transforms/treemap/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('transform.voronoi', 'Interface', '/docs/transforms/voronoi/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('transform.window', 'Interface', '/docs/transforms/window/index.html');\n",
+      "INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('transform.wordcloud', 'Interface', '/docs/transforms/wordcloud/index.html');\n",
+      "connection closed\n"
+     ]
+    }
+   ],
    "source": [
     "try:\n",
-    "    # TODO: evaluate if this needs to become indempotent\n",
+    "    # TODO: evaluate if this needs to become idempotent\n",
     "    connection = sqlite3.connect(SQLITE_PATH)\n",
     "    cursor = connection.cursor()\n",
     "    \n",
@@ -666,33 +875,24 @@
     "    if connection:\n",
     "        connection.close()\n",
     "        print('connection closed')"
-   ],
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Error while executing sqlite script table searchIndex already exists\n",
-      "connection closed\n"
-     ]
-    }
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 22,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# logos from https://github.com/vega/logos\n",
     "#!curl https://github.com/vega/logos/blob/master/assets/VG_Color%40128.png  \n",
     "!cp img/* $VEGA_DOCSET/"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 23,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "def enrich_table_of_contents(filename):\n",
     "    with open(filename) as fp:\n",
@@ -743,6 +943,7 @@
     "        dashAnchor = soup.new_tag(\"a\")\n",
     "        dashAnchor[\"name\"] = f\"//apple_ref/cpp/Section/{safeName}\"\n",
     "        dashAnchor[\"class\"] = \"dashAnchor\"\n",
+    "\n",
     "        anchor.append(dashAnchor)\n",
     "\n",
     "    print(\n",
@@ -755,13 +956,13 @@
     "    )\n",
     "\n",
     "    return str(soup)\n"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 24,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "def remove_page_elements(filename):\n",
     "    with open(filename) as fp:\n",
@@ -776,32 +977,18 @@
     "        sidebar.decompose()\n",
     "    \n",
     "    return str(soup)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 25,
-   "source": [
-    "# Add \"toc\" entries for each page.\n",
-    "matches = glob.glob(f\"vega-docs/**/*.html\", recursive=True)\n",
-    "print(len(matches))\n",
-    "\n",
-    "for name in matches:\n",
-    "    if DEBUG:\n",
-    "        print('Enrich table of contents', name)\n",
-    "    processed = enrich_table_of_contents(name)\n",
-    "    \n",
-    "    with open(name, 'w') as fp:\n",
-    "        fp.write(processed)"
-   ],
+   "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "188\n",
+      "192\n",
       "Enrich table of contents vega-docs/index.html\n",
       "Added 0 sections 0 functions 0\n",
       "Enrich table of contents vega-docs/usage/index.html\n",
@@ -821,12 +1008,26 @@
       "Enrich table of contents vega-docs/about/vega-and-d3/index.html\n",
       "Added 0 sections 0 functions 0\n",
       "Enrich table of contents vega-docs/about/code-of-conduct/index.html\n",
-      "Added 0 sections 6 functions 0\n",
+      "Added 0 sections 0 functions 0\n",
       "Enrich table of contents vega-docs/docs/index.html\n",
       "Added 0 sections 2 functions 0\n",
       "Enrich table of contents vega-docs/docs/schemes/index.html\n",
       "Added 5 sections 3 functions 67\n",
-      "Enrich table of contents vega-docs/docs/event-streams/index.html\n",
+      "Enrich table of contents vega-docs/docs/event-streams/index.html\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/var/folders/rw/wjb8b8ws1td2934nl9bk7_tm0000gp/T/ipykernel_13044/3527363842.py:42: DeprecationWarning: The 'text' argument to find()-type methods is deprecated. Use 'string' instead.\n",
+      "  function_anchors = content.findAll(\"a\", text=\"#\")\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "Added 5 sections 5 functions 0\n",
       "Enrich table of contents vega-docs/docs/types/index.html\n",
       "Added 0 sections 3 functions 23\n",
@@ -983,7 +1184,7 @@
       "Enrich table of contents vega-docs/docs/transforms/isocontour/index.html\n",
       "Added 0 sections 2 functions 0\n",
       "Enrich table of contents vega-docs/docs/expressions/index.html\n",
-      "Added 0 sections 22 functions 176\n",
+      "Added 0 sections 22 functions 178\n",
       "Enrich table of contents vega-docs/docs/api/statistics/index.html\n",
       "Added 1 sections 5 functions 35\n",
       "Enrich table of contents vega-docs/docs/api/locale/index.html\n",
@@ -1026,6 +1227,8 @@
       "Added 1 sections 0 functions 0\n",
       "Enrich table of contents vega-docs/examples/wheat-and-wages/index.html\n",
       "Added 1 sections 0 functions 0\n",
+      "Enrich table of contents vega-docs/examples/zoomable-circle-packing/index.html\n",
+      "Added 1 sections 0 functions 0\n",
       "Enrich table of contents vega-docs/examples/word-cloud/index.html\n",
       "Added 1 sections 0 functions 0\n",
       "Enrich table of contents vega-docs/examples/u-district-cuisine/index.html\n",
@@ -1063,6 +1266,8 @@
       "Enrich table of contents vega-docs/examples/population-pyramid/index.html\n",
       "Added 1 sections 0 functions 0\n",
       "Enrich table of contents vega-docs/examples/global-development/index.html\n",
+      "Added 1 sections 0 functions 0\n",
+      "Enrich table of contents vega-docs/examples/serpentine-timeline/index.html\n",
       "Added 1 sections 0 functions 0\n",
       "Enrich table of contents vega-docs/examples/annual-temperature/index.html\n",
       "Added 1 sections 0 functions 0\n",
@@ -1130,6 +1335,8 @@
       "Added 1 sections 0 functions 0\n",
       "Enrich table of contents vega-docs/examples/probability-density/index.html\n",
       "Added 1 sections 0 functions 0\n",
+      "Enrich table of contents vega-docs/examples/warming-stripes/index.html\n",
+      "Added 1 sections 0 functions 0\n",
       "Enrich table of contents vega-docs/examples/horizon-graph/index.html\n",
       "Added 1 sections 0 functions 0\n",
       "Enrich table of contents vega-docs/examples/regression/index.html\n",
@@ -1162,6 +1369,8 @@
       "Added 1 sections 0 functions 0\n",
       "Enrich table of contents vega-docs/examples/clock/index.html\n",
       "Added 1 sections 0 functions 0\n",
+      "Enrich table of contents vega-docs/examples/packed-bubble-chart/index.html\n",
+      "Added 1 sections 0 functions 0\n",
       "Enrich table of contents vega-docs/examples/earthquakes/index.html\n",
       "Added 1 sections 0 functions 0\n",
       "Enrich table of contents vega-docs/examples/histogram/index.html\n",
@@ -1181,28 +1390,30 @@
      ]
     }
    ],
-   "metadata": {}
+   "source": [
+    "# Add \"toc\" entries for each page.\n",
+    "matches = glob.glob(f\"vega-docs/**/*.html\", recursive=True)\n",
+    "print(len(matches))\n",
+    "\n",
+    "for name in matches:\n",
+    "    if DEBUG:\n",
+    "        print('Enrich table of contents', name)\n",
+    "    processed = enrich_table_of_contents(name)\n",
+    "    \n",
+    "    with open(name, 'w') as fp:\n",
+    "        fp.write(processed)"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 26,
-   "source": [
-    "matches = glob.glob(f\"vega-docs/**/*.html\", recursive=True)\n",
-    "if DEBUG:\n",
-    "    print('Files', len(matches))\n",
-    "for name in matches:    \n",
-    "    # https://stackoverflow.com/questions/5598524/can-i-remove-script-tags-with-beautifulsoup\n",
-    "    processed = remove_page_elements(name)\n",
-    "    \n",
-    "    with open(name, 'w') as fp:\n",
-    "        fp.write(processed)"
-   ],
+   "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "Files 188\n",
+      "Files 192\n",
       "removing sidebar from  vega-docs/about/index.html\n",
       "removing sidebar from  vega-docs/about/research/index.html\n",
       "removing sidebar from  vega-docs/about/video/index.html\n",
@@ -1300,29 +1511,41 @@
      ]
     }
    ],
-   "metadata": {}
+   "source": [
+    "matches = glob.glob(f\"vega-docs/**/*.html\", recursive=True)\n",
+    "if DEBUG:\n",
+    "    print('Files', len(matches))\n",
+    "for name in matches:    \n",
+    "    # https://stackoverflow.com/questions/5598524/can-i-remove-script-tags-with-beautifulsoup\n",
+    "    processed = remove_page_elements(name)\n",
+    "    \n",
+    "    with open(name, 'w') as fp:\n",
+    "        fp.write(processed)"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 27,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "from urllib.parse import urlparse"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 28,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "#urlparse('../../foobar/index.html#specification')"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 29,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# tack on HTML paths\n",
     "def update_html_paths(filename):\n",
@@ -1340,6 +1563,11 @@
     "  \n",
     "    for link in links:\n",
     "      ref = link.get('href')\n",
+    "\n",
+    "      # if ref and \"CODE_OF_CONDUCT\" in ref:\n",
+    "      #   print(ref)\n",
+    "\n",
+    "        \n",
     "      if ref and not \"https://\" in ref and ref.endswith('/'):\n",
     "        link['href'] = ref + 'index.html'\n",
     "        numUpdated += 1\n",
@@ -1347,9 +1575,10 @@
     "        pass # ignore schema updates\n",
     "      elif ref and ref.startswith('#'):\n",
     "        pass # ignore self links\n",
-    "      elif ref and not 'http' in ref and not ref.endswith('.html'):\n",
+    "      elif ref and not 'http' in ref and not (ref.endswith('.html') or ref.endswith('.md')):\n",
     "        # link['href'] = ref + '/index.html'\n",
     "        parsed = urlparse(ref)\n",
+    "        \n",
     "        if parsed.fragment:\n",
     "          subpath = parsed.path + 'index.html' if parsed.path.endswith('/') else parsed.path + '/index.html'\n",
     "          link['href'] = subpath + f\"#{parsed.fragment}\"\n",
@@ -1358,46 +1587,34 @@
     "\n",
     "        numUpdated += 1\n",
     "\n",
-    "    print(f\"updated {numUpdated}\")\n",
+    "      # if ref and \"CODE_OF_CONDUCT\" in ref:\n",
+    "      #   print(link['href'])\n",
     "\n",
+    "    print(f\"updated {numUpdated}\")\n",
     "    \n",
     "    return str(soup)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 30,
-   "source": [
-    "# updated \n",
-    "matches = glob.glob(f\"vega-docs/**/*.html\", recursive=True)\n",
-    "print(len(matches))\n",
-    "\n",
-    "for name in matches:\n",
-    "    if DEBUG:\n",
-    "        print('Update HTML paths', name)\n",
-    "    processed = update_html_paths(name)\n",
-    "    \n",
-    "    with open(name, 'w') as fp:\n",
-    "        fp.write(processed)"
-   ],
+   "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "188\n",
+      "192\n",
       "Update HTML paths vega-docs/index.html\n",
       "updated 19\n",
       "Update HTML paths vega-docs/usage/index.html\n",
-      "updated 13\n",
+      "updated 12\n",
       "Update HTML paths vega-docs/usage/interpreter/index.html\n",
       "updated 6\n",
       "Update HTML paths vega-docs/usage/internet-explorer/index.html\n",
       "updated 7\n",
       "Update HTML paths vega-docs/about/index.html\n",
-      "updated 12\n",
+      "updated 11\n",
       "Update HTML paths vega-docs/about/research/index.html\n",
       "updated 6\n",
       "Update HTML paths vega-docs/about/video/index.html\n",
@@ -1407,7 +1624,7 @@
       "Update HTML paths vega-docs/about/vega-and-d3/index.html\n",
       "updated 8\n",
       "Update HTML paths vega-docs/about/code-of-conduct/index.html\n",
-      "updated 8\n",
+      "updated 6\n",
       "Update HTML paths vega-docs/docs/index.html\n",
       "updated 43\n",
       "Update HTML paths vega-docs/docs/schemes/index.html\n",
@@ -1561,7 +1778,7 @@
       "Update HTML paths vega-docs/docs/transforms/sequence/index.html\n",
       "updated 11\n",
       "Update HTML paths vega-docs/docs/transforms/force/index.html\n",
-      "updated 44\n",
+      "updated 45\n",
       "Update HTML paths vega-docs/docs/transforms/treemap/index.html\n",
       "updated 23\n",
       "Update HTML paths vega-docs/docs/transforms/nest/index.html\n",
@@ -1589,7 +1806,7 @@
       "Update HTML paths vega-docs/docs/data/index.html\n",
       "updated 33\n",
       "Update HTML paths vega-docs/examples/index.html\n",
-      "updated 90\n",
+      "updated 94\n",
       "Update HTML paths vega-docs/examples/arc-diagram/index.html\n",
       "updated 8\n",
       "Update HTML paths vega-docs/examples/platformer/index.html\n",
@@ -1612,6 +1829,8 @@
       "updated 8\n",
       "Update HTML paths vega-docs/examples/wheat-and-wages/index.html\n",
       "updated 8\n",
+      "Update HTML paths vega-docs/examples/zoomable-circle-packing/index.html\n",
+      "updated 9\n",
       "Update HTML paths vega-docs/examples/word-cloud/index.html\n",
       "updated 11\n",
       "Update HTML paths vega-docs/examples/u-district-cuisine/index.html\n",
@@ -1649,6 +1868,8 @@
       "Update HTML paths vega-docs/examples/population-pyramid/index.html\n",
       "updated 8\n",
       "Update HTML paths vega-docs/examples/global-development/index.html\n",
+      "updated 8\n",
+      "Update HTML paths vega-docs/examples/serpentine-timeline/index.html\n",
       "updated 8\n",
       "Update HTML paths vega-docs/examples/annual-temperature/index.html\n",
       "updated 9\n",
@@ -1716,6 +1937,8 @@
       "updated 11\n",
       "Update HTML paths vega-docs/examples/probability-density/index.html\n",
       "updated 9\n",
+      "Update HTML paths vega-docs/examples/warming-stripes/index.html\n",
+      "updated 8\n",
       "Update HTML paths vega-docs/examples/horizon-graph/index.html\n",
       "updated 9\n",
       "Update HTML paths vega-docs/examples/regression/index.html\n",
@@ -1748,6 +1971,8 @@
       "updated 9\n",
       "Update HTML paths vega-docs/examples/clock/index.html\n",
       "updated 8\n",
+      "Update HTML paths vega-docs/examples/packed-bubble-chart/index.html\n",
+      "updated 8\n",
       "Update HTML paths vega-docs/examples/earthquakes/index.html\n",
       "updated 9\n",
       "Update HTML paths vega-docs/examples/histogram/index.html\n",
@@ -1767,20 +1992,25 @@
      ]
     }
    ],
-   "metadata": {}
+   "source": [
+    "# updated \n",
+    "matches = glob.glob(f\"vega-docs/**/*.html\", recursive=True)\n",
+    "print(len(matches))\n",
+    "\n",
+    "for name in matches:\n",
+    "    if DEBUG:\n",
+    "        print('Update HTML paths', name)\n",
+    "    processed = update_html_paths(name)\n",
+    "    \n",
+    "    with open(name, 'w') as fp:\n",
+    "        fp.write(processed)"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 31,
-   "source": [
-    "#!rsync -r ../vega-lite/site/_site/* ./vega-lite-docs"
-   ],
+   "metadata": {},
    "outputs": [],
-   "metadata": {}
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 32,
    "source": [
     "# Move HTML into the right directory\n",
     "#!rsync -r ../vega-lite/site/_site/* ./vega-lite-docs\n",
@@ -1788,43 +2018,41 @@
     "!rsync -r ./vega-docs/* $DOCSET_PATH \\\n",
     "     --exclude 'data/*.csv' --exclude 'data/*.arrow' --exclude 'data/*.json' --exclude 'data/*.tsv' \\\n",
     "     --exclude 'sitemap.xml' --exclude '*min.js.map' --exclude 'rollup.config.js' --exclude 'releases/' --exclude 'robots.txt' --exclude 'vega-schema.json'"
-   ],
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
    "outputs": [],
-   "metadata": {}
+   "source": [
+    "# !mkdir ../Dash-User-Contributions/docsets/Vega/"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 33,
-   "source": [
-    "# !mkdir ../Dash-User-Contributions/docsets/Vega/"
-   ],
+   "metadata": {},
    "outputs": [],
-   "metadata": {}
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 34,
    "source": [
     "# Prepare to publish in adjacent user contribs repository\n",
-    "#!tar --exclude='.DS_Store' -cvzf vega.tgz vega.docset\n",
-    "#!cp vega.tgz ../Dash-User-Contributions/docsets/Vega/"
-   ],
-   "outputs": [],
-   "metadata": {}
+    "# !tar --exclude='.DS_Store' -cvzf vega.tgz vega.docset\n",
+    "# !cp vega.tgz ../Dash-User-Contributions/docsets/Vega/"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "source": [],
+   "metadata": {},
    "outputs": [],
-   "metadata": {}
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.7.1 64-bit ('jupyter3': venv)",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "python37164bitjupyter3venvb467f83f0de74782bfaecabfaba39166"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1836,9 +2064,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.12.1"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
## Motivation

- Without handling this case, we would get errors about linking to non-existent files:
  - Example: https://github.com/Kapeli/Dash-User-Contributions/pull/4807#issuecomment-1925903968

## Changes

Changed `get_guide_entries`

```python
path.join('/', path.relpath(l["href"], "../"), 'index.html') if not 'https:' in l["href"] else l["href"]
```
